### PR TITLE
Fix GitHub alignment in header

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -35,9 +35,18 @@ header {
 .github a { color: white; }
 
 .github img {
-	width: 33px;
+	width: 30px;
 	margin-left: 10px;
-	vertical-align: middle;
+	margin-top: 2px;
+}
+
+.github .text {
+	position: relative;
+	top: -10px;
+}
+
+.github .text, .github img {
+	display: inline-block;
 }
 
 footer {
@@ -230,7 +239,12 @@ img.usda {
 
 	#main-cont { min-height: calc(100vh - 173px); }
 
-	.github img { width: 25px; }
+	.github img {
+		width: 25px;
+		margin-top: 0px;
+	}
+
+	.github text { top: -7px; }
 
 	footer { height: auto; }
 

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
           </span>
           <div class="github">
             <a href="https://github.com/IndigoBox/is-it-fresh" target="_blank">
-              Fork On GitHub
+              <div class="text">Fork On GitHub</div>
               <img src="imgs/github_logo.png" >
             </a>
           </div>


### PR DESCRIPTION
Should fix the alignment issue plaguing the GitHub link in the header.